### PR TITLE
✨ feat: support for tsconfig paths and babel macros

### DIFF
--- a/packages/babel-preset/index.js
+++ b/packages/babel-preset/index.js
@@ -1,3 +1,5 @@
+const getPathsPlugin = require('./tsconfig-paths');
+
 const MIN_NODE_VERSION = '12';
 
 const nodeConfig = {
@@ -21,6 +23,27 @@ const nodeConfig = {
   ],
 };
 
+const plugins = [
+  '@babel/plugin-proposal-class-properties',
+  'macros',
+  'inline-react-svg',
+  ['import', { libraryName: 'antd' }, 'antd'],
+  [
+    'import',
+    {
+      libraryName: 'lodash',
+      libraryDirectory: '',
+      camel2DashComponentName: false,
+    },
+    'lodash',
+  ],
+];
+
+const pathsPlugin = getPathsPlugin();
+if (pathsPlugin) {
+  plugins.push(pathsPlugin);
+}
+
 module.exports = (api) => {
   api.assertVersion(7);
 
@@ -38,20 +61,7 @@ module.exports = (api) => {
         },
       ],
     ],
-    plugins: [
-      '@babel/plugin-proposal-class-properties',
-      'inline-react-svg',
-      ['import', { libraryName: 'antd' }, 'antd'],
-      [
-        'import',
-        {
-          libraryName: 'lodash',
-          libraryDirectory: '',
-          camel2DashComponentName: false,
-        },
-        'lodash',
-      ],
-    ],
+    plugins,
     env: {
       node: nodeConfig,
       test: nodeConfig,

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -5,7 +5,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "5.10.0",
+  "version": "5.11.0-chad.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/GrowflowTeam/javascript.git"
@@ -23,6 +23,10 @@
     "@babel/preset-react": "^7.12.10",
     "@babel/preset-typescript": "^7.10.4",
     "babel-plugin-import": "^1.13.3",
-    "babel-plugin-inline-react-svg": "^1.1.2"
+    "babel-plugin-inline-react-svg": "^1.1.2",
+    "babel-plugin-macros": "^3.0.1",
+    "babel-plugin-module-resolver": "^4.1.0",
+    "lodash": "^4.17.20",
+    "optional-require": "^1.0.2"
   }
 }

--- a/packages/babel-preset/tsconfig-paths.js
+++ b/packages/babel-preset/tsconfig-paths.js
@@ -1,0 +1,29 @@
+const path = require('path');
+const optionalRequire = require('optional-require')(require);
+const get = require('lodash/get');
+
+const tsConfig = optionalRequire(path.join(process.cwd(), 'tsconfig.json'));
+
+module.exports = function getPlugin() {
+  const baseUrl = get(tsConfig, 'compilerOptions.baseUrl');
+  const paths = get(tsConfig, 'compilerOptions.paths');
+
+  if (!baseUrl && !paths) return;
+
+  const alias = {};
+
+  for (const k of Object.keys(paths)) {
+    alias[k] = `./${path.relative(
+      process.cwd(),
+      path.resolve(baseUrl, paths[k][0])
+    )}`;
+  }
+
+  return [
+    'module-resolver',
+    {
+      root: [baseUrl],
+      alias,
+    },
+  ];
+};

--- a/packages/eslint/core.js
+++ b/packages/eslint/core.js
@@ -26,6 +26,13 @@ module.exports = {
     node: true,
     browser: true,
   },
+  settings: {
+    'import/resolver': {
+      'babel-module': {
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
+      },
+    },
+  },
   rules: {
     // sort imports
     'simple-import-sort/imports': 'error',

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -26,6 +26,7 @@
     "@typescript-eslint/eslint-plugin": "^4.11.0",
     "@typescript-eslint/parser": "^4.14.0",
     "eslint": "^7.16.0",
+    "eslint-import-resolver-babel-module": "^5.2.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.1.3",


### PR DESCRIPTION
This adds support for loading [`baseUrl` and `paths` configuration from tsconfig](https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-url) and syncing that to [babel's `module-resolver` plugin](https://github.com/tleunen/babel-plugin-module-resolver) so that babel, TypeScript, and ESLint (via [this import resolver](https://github.com/tleunen/eslint-import-resolver-babel-module)) all know how to resolve modules in the same way.

Effectively, it makes things "just work" when using TypeScript's paths config. This fixes issues in both Retail and the payment service.