### PR TITLE
Include next/core-web-vitals rules in base eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,8 +3,5 @@ module.exports = {
   parserOptions: {
     project: 'tsconfig.json',
   },
-  root: true,
-  rules: {
-    'unicorn/prefer-module': 'off',
-  },
+  root: true
 };

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "devDependencies": {
     "@babel/cli": "^7.15.4",
     "@babel/core": "^7.15.5",
-    "@growflow/babel-preset": "^6.0.0",
-    "@growflow/eslint-config": "^6.0.0",
+    "@growflow/babel-preset": "^7.0.0",
+    "@growflow/eslint-config": "^7.0.0",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",
     "eslint": "^7.32.0",

--- a/packages/eslint/core.js
+++ b/packages/eslint/core.js
@@ -98,6 +98,7 @@ module.exports = {
     'unicorn/no-object-as-default-parameter': 'off',
     'unicorn/number-literal-case': 'off',
     'unicorn/empty-brace-spaces': 'off',
+    'unicorn/prefer-module': 'off',
 
     // we use async/await instead of promise chains and don't want to be forced to return in a then()
     'promise/always-return': 'off',

--- a/packages/eslint/core.js
+++ b/packages/eslint/core.js
@@ -13,6 +13,7 @@ module.exports = {
     'airbnb',
     'airbnb-typescript',
     'airbnb/hooks',
+    'next/core-web-vitals',
     'plugin:eslint-comments/recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:@typescript-eslint/recommended-requiring-type-checking',

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-airbnb-typescript": "^14.0.0",
+    "eslint-config-next": "^11.1.2",
     "eslint-config-prettier": "^8.3.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Baking in the [nextjs integration](https://nextjs.org/docs/basic-features/eslint).