### PR TITLE
Fix: Use before define rules when targeting ES6+

### DIFF
--- a/packages/eslint/core.js
+++ b/packages/eslint/core.js
@@ -90,10 +90,6 @@ module.exports = {
     // it's probably fine
     'no-await-in-loop': 'warn',
 
-    // this is really only an issue if you are using var (instead of let/const), which we are not
-    'no-use-before-define': 'off',
-    '@typescript-eslint/no-use-before-define': 'off',
-
     // https://stackoverflow.com/a/63833015/316108
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': 'error',

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -5,7 +5,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "10.2.0",
+  "version": "10.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/GrowflowTeam/javascript.git"


### PR DESCRIPTION
Shipping `let` and `const` to the client means use before define is a runtime exception now.