### PR TITLE
Fix: functions are hoisted, it's fine to lazily declare them

### DIFF
--- a/packages/eslint/core.js
+++ b/packages/eslint/core.js
@@ -90,6 +90,16 @@ module.exports = {
     // it's probably fine
     'no-await-in-loop': 'warn',
 
+    // functions are hoisted. why is this not the default?
+    'no-use-before-define': [
+      'error',
+      {
+        functions: false,
+        classes: true,
+        variables: true,
+      },
+    ],
+
     // https://stackoverflow.com/a/63833015/316108
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': 'error',

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -5,7 +5,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "10.3.0",
+  "version": "10.3.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/GrowflowTeam/javascript.git"


### PR DESCRIPTION
This should probably be the default, but hey, I'm no eslint contributor